### PR TITLE
Added support for Spring's ContentNegotiatingViewResolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <gae.version>1.5.4</gae.version>
-        <gae.runtime>1.5.4</gae.runtime>
+        <gae.version>1.5.5</gae.version>
+        <gae.runtime>1.5.5</gae.runtime>
         <gae.home>${settings.localRepository}/com/google/appengine/appengine-java-sdk/${gae.version}/appengine-java-sdk-${gae.version}</gae.home>
         <rebel.home>${env.REBEL_HOME}</rebel.home>
-        <maven.gae.plugin.version>0.9.1</maven.gae.plugin.version>
+        <maven.gae.plugin.version>0.9.2</maven.gae.plugin.version>
         <datanucleus.version>1.1.5</datanucleus.version>
         <springframework.version>3.0.6.RELEASE</springframework.version>
         <springframework.security.version>3.0.7.RELEASE</springframework.security.version>

--- a/src/main/java/com/jappstart/controller/LoginController.java
+++ b/src/main/java/com/jappstart/controller/LoginController.java
@@ -18,7 +18,6 @@
  */
 package com.jappstart.controller;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +26,6 @@ import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.jappstart.model.auth.UserAccount;
 import com.jappstart.service.auth.EnhancedUserDetailsService;
@@ -79,24 +77,18 @@ public class LoginController {
     /**
      * Determines if an account with the given username exists or not.
      *
+     * @param modelMap the model map
      * @param request the request
      * @return the response
      */
     @RequestMapping(value = "/login/validate", method = RequestMethod.POST)
-    @ResponseBody
-    public final Map<String, Boolean> validate(
+    public final String validate(final ModelMap modelMap,
         @RequestBody final Map<String, String> request) {
-        final Map<String, Boolean> response = new HashMap<String, Boolean>();
         final UserAccount user =
             userDetailsService.getUser(request.get("username"));
 
-        if (user == null) {
-            response.put("found", false);
-        } else {
-            response.put("found", true);
-        }
-
-        return response;
+        modelMap.put("found", user != null);
+        return null;
     }
 
 }

--- a/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -52,6 +52,21 @@
         <property name="cookieName" value="USER_LOCALE" />
         <property name="cookieMaxAge" value="1209600" />
     </bean>
+    
+    <bean id="contentNegotiatingViewResolver" class="org.springframework.web.servlet.view.ContentNegotiatingViewResolver">
+		<property name="order" value="1" />
+		<property name="mediaTypes">
+			<map>
+				<entry key="json" value="application/json" />
+				<entry key="html" value="text/html" />
+			</map>
+		</property>
+		<property name="defaultViews">
+			<list>
+				<bean class="org.springframework.web.servlet.view.json.MappingJacksonJsonView" />
+			</list>
+		</property>
+	</bean>
 
     <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <property name="prefix" value="/WEB-INF/view/" />


### PR DESCRIPTION
This would be a great feature to add to jappstart. The ContentNegotiatingViewResolver is handy for being able to return controller model attributes as JSON so you can render them with JS. I added the configuration to the dispatcher servlet and updated the /login/validate controller method to use this instead of @ResponseBody.
